### PR TITLE
Allow sizing output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
-./*.gcode
+/*.gcode
+/*.svg

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,12 @@ struct Opt {
     /// Dots per inch (DPI) for pixels, points, picas, etc.
     #[structopt(long, default_value = "96")]
     dpi: f64,
+    /// Width with optional unit. Specify either width or height will retain aspect ratio. Specify both will stretch the result.
+    #[structopt(short, long)]
+    width: Option<String>,
+    /// Height with optional unit. Specify either width or height will retain aspect ratio. Specify both will stretch the result.
+    #[structopt(short, long)]
+    height: Option<String>,
     #[structopt(alias = "tool_on_sequence", long = "on")]
     /// Tool on GCode sequence
     tool_on_sequence: Option<String>,
@@ -87,6 +93,8 @@ fn main() -> io::Result<()> {
         tolerance: opt.tolerance,
         feedrate: opt.feedrate,
         dpi: opt.dpi,
+        width: opt.width,
+        height: opt.height,
     };
 
     let snippets = [


### PR DESCRIPTION
Certain tool I'm using to generate svg does not output width and height attribute in the root <svg >. In the browser, these svgs would fit their parent, but that is not applicable in our case. I think adding option to specify size is a good solution for this case.

For svgs with these attributes, being able to quickly resize drawing would still be useful I think.

This implementation will allow specifying either width or height, keeping aspect ratio; or both to stretch the result. The aspect ratio come from the first viewBox, not sure if that is a good assumption.