### PR TITLE
Implement support for more shapes

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -191,6 +191,21 @@ mod test {
     }
 
     #[test]
+    fn svg_dimensions_produces_expected_gcode() {
+        let svg = include_str!("../tests/dimensions.svg");
+
+        let expected = g_code::parse::file_parser(include_str!("../tests/dimensions.gcode"))
+            .unwrap()
+            .iter_emit_tokens()
+            .collect::<Vec<_>>();
+
+        assert_close(
+            get_actual(svg, true, [None; 2]),
+            expected,
+        );
+    }
+
+    #[test]
     #[cfg(feature = "serde")]
     fn deserialize_v1_config_succeeds() {
         let json = r#"

--- a/lib/tests/dimensions.gcode
+++ b/lib/tests/dimensions.gcode
@@ -1,49 +1,91 @@
 G21
-G90;svg > g > polygon#page-bounds
-G0 X0 Y400
-G1 X0 Y200 F300
+G90
+
+;svg > polygon#page-bounds
+G0 X0   Y400
+G1 X0   Y200 F300
 G1 X200 Y200 F300
 G1 X200 Y400 F300
-G1 X0 Y400 F300
-G1 X0 Y400 F300;svg > g > line#unitless-H
+G1 X0   Y400 F300
+
+;svg > g > line#unitless-H
 G0 X10 Y390
-G1 X110 Y390 F300;svg > g > line#unitless-V
+G1 X110 Y390 F300
+
+;svg > g > line#unitless-V
 G0 X10 Y390
-G1 X10 Y290 F300;svg > g > line#px-H
+G1 X10 Y290 F300
+
+;svg > g > line#px-H
 G0 X20 Y380
-G1 X120 Y380 F300;svg > g > line#px-V
+G1 X120 Y380 F300
+
+;svg > g > line#px-V
 G0 X20 Y380
-G1 X20 Y280 F300;svg > g > line#mm-H
+G1 X20 Y280 F300
+
+;svg > g > line#mm-H
 G0 X30 Y370
-G1 X130 Y370 F300;svg > g > line#mm-V
+G1 X130 Y370 F300
+
+;svg > g > line#mm-V
 G0 X30 Y370
-G1 X30 Y270 F300;svg > g > line#cm-H
+G1 X30 Y270 F300
+
+;svg > g > line#cm-H
 G0 X40 Y360
-G1 X140 Y360 F300;svg > g > line#cm-V
+G1 X140 Y360 F300
+
+;svg > g > line#cm-V
 G0 X40 Y360
-G1 X40 Y260 F300;svg > g > line#in-H
+G1 X40 Y260 F300
+
+;svg > g > line#in-H
 G0 X50 Y350
-G1 X150 Y350 F300;svg > g > line#in-V
+G1 X150 Y350 F300
+
+;svg > g > line#in-V
 G0 X50 Y350
-G1 X50 Y250 F300;svg > g > line#em-H
+G1 X50 Y250 F300
+
+;svg > g > line#em-H
 G0 X60 Y340
-G1 X160 Y340 F300;svg > g > line#em-V
+G1 X160 Y340 F300
+
+;svg > g > line#em-V
 G0 X60 Y340
-G1 X60 Y240 F300;svg > g > line#ex-H
+G1 X60 Y240 F300
+
+;svg > g > line#ex-H
 G0 X70 Y330
-G1 X170 Y330 F300;svg > g > line#ex-V
+G1 X170 Y330 F300
+
+;svg > g > line#ex-V
 G0 X70 Y330
-G1 X70 Y230 F300;svg > g > line#pct-H
+G1 X70 Y230 F300
+
+;svg > g > line#pct-H
 G0 X80 Y320
-G1 X180 Y320 F300;svg > g > line#pct-V
+G1 X180 Y320 F300
+
+;svg > g > line#pct-V
 G0 X80 Y320
-G1 X80 Y220 F300;svg > g > line#pt-H
+G1 X80 Y220 F300
+
+;svg > g > line#pt-H
 G0 X90 Y310
-G1 X190 Y310 F300;svg > g > line#pt-V
+G1 X190 Y310 F300
+
+;svg > g > line#pt-V
 G0 X90 Y310
-G1 X90 Y210 F300;svg > g > line#pc-H
+G1 X90 Y210 F300
+
+;svg > g > line#pc-H
 G0 X100 Y300
-G1 X200 Y300 F300;svg > g > line#pc-V
+G1 X200 Y300 F300
+
+;svg > g > line#pc-V
 G0 X100 Y300
 G1 X100 Y200 F300
+
 M2

--- a/lib/tests/dimensions.gcode
+++ b/lib/tests/dimensions.gcode
@@ -1,0 +1,49 @@
+G21
+G90;svg > g > polygon#page-bounds
+G0 X0 Y400
+G1 X0 Y200 F300
+G1 X200 Y200 F300
+G1 X200 Y400 F300
+G1 X0 Y400 F300
+G1 X0 Y400 F300;svg > g > line#unitless-H
+G0 X10 Y390
+G1 X110 Y390 F300;svg > g > line#unitless-V
+G0 X10 Y390
+G1 X10 Y290 F300;svg > g > line#px-H
+G0 X20 Y380
+G1 X120 Y380 F300;svg > g > line#px-V
+G0 X20 Y380
+G1 X20 Y280 F300;svg > g > line#mm-H
+G0 X30 Y370
+G1 X130 Y370 F300;svg > g > line#mm-V
+G0 X30 Y370
+G1 X30 Y270 F300;svg > g > line#cm-H
+G0 X40 Y360
+G1 X140 Y360 F300;svg > g > line#cm-V
+G0 X40 Y360
+G1 X40 Y260 F300;svg > g > line#in-H
+G0 X50 Y350
+G1 X150 Y350 F300;svg > g > line#in-V
+G0 X50 Y350
+G1 X50 Y250 F300;svg > g > line#em-H
+G0 X60 Y340
+G1 X160 Y340 F300;svg > g > line#em-V
+G0 X60 Y340
+G1 X60 Y240 F300;svg > g > line#ex-H
+G0 X70 Y330
+G1 X170 Y330 F300;svg > g > line#ex-V
+G0 X70 Y330
+G1 X70 Y230 F300;svg > g > line#pct-H
+G0 X80 Y320
+G1 X180 Y320 F300;svg > g > line#pct-V
+G0 X80 Y320
+G1 X80 Y220 F300;svg > g > line#pt-H
+G0 X90 Y310
+G1 X190 Y310 F300;svg > g > line#pt-V
+G0 X90 Y310
+G1 X90 Y210 F300;svg > g > line#pc-H
+G0 X100 Y300
+G1 X200 Y300 F300;svg > g > line#pc-V
+G0 X100 Y300
+G1 X100 Y200 F300
+M2

--- a/lib/tests/dimensions.svg
+++ b/lib/tests/dimensions.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" standalone="no"?>
+<svg
+    width="200mm"
+    height="400mm"
+    viewBox="0 -20 100 200"
+    xmlns="http://www.w3.org/2000/svg"
+    version="1.1"
+>
+    <!-- Manually constructed SVG
+    
+        It draws several lines, each with a different unit, but all of them
+        should be exactly 50 units long. As the 100px width viewport maps to
+        200mm, that should equal 100mm. This has been verified with Inkscape
+        and Firefox.
+
+        The viewbox doesn't start on origin on purpose, so we also test 
+        origin-based math here.
+
+        Two units are font-dependent (em and ex). Calculations with those are
+        underdefined as long as there's no font support. These cases these are
+        marked with class="font-dependent", and styled in red.
+    -->
+
+    <style>
+        * {
+            stroke: #059;
+            stroke-width: 1;
+            fill: none;
+        }
+
+        .font-dependent {
+            stroke: #f00;
+        }
+    </style>
+
+    <!-- A line around the page, so a visual inspection is easy -->
+    <g transform="translate(0 -20)">
+        <polygon  points="0,0 0,100 100,100 100,0 0,0" id="page-bounds"/>
+    </g>
+
+    <!-- Unitless (equivalent to pixels)-->
+    <g transform="translate(5 -15)">
+        <line x1="0" y1="0" x2="50" y2="0" id="unitless-H" />
+        <line x1="0" y1="0" x2="0" y2="50" id="unitless-V" />
+    </g>
+
+    <!-- px -->
+    <g transform="translate(10 -10)">
+        <line x1="0" y1="0" x2="50px" y2="0"  id="px-H"/>
+        <line x1="0" y1="0" x2="0" y2="50px"  id="px-V"/>
+    </g>
+
+    <!-- 1mm = (96dpi / 25.4mm/in ) px -->
+    <g transform="translate(15 -5)">
+        <line x1="0" y1="0" x2="13.3333333mm" y2="0"  id="mm-H"/>
+        <line x1="0" y1="0" x2="0" y2="13.333333mm"  id="mm-V"/>
+    </g>
+
+    <!-- 1cm = (96dpi / 2.54cm/in ) px -->
+    <g transform="translate(20 0)">
+        <line x1="0" y1="0" x2="1.33333333cm" y2="0"  id="cm-H"/>
+        <line x1="0" y1="0" x2="0" y2="1.3333333cm"  id="cm-V"/>
+    </g>
+
+    <!-- 1in = (96dpi) px -->
+    <g transform="translate(25 5)">
+        <line x1="0" y1="0" x2=".52083in" y2="0"  id="in-H"/>
+        <line x1="0" y1="0" x2="0" y2=".52083in"  id="in-V"/>
+    </g>
+
+    <!-- 1em = font dependent.
+        Inkscape 1.3.2 on debian bookworm uses 12px (used for this test)
+        Firefox 115.5 on debian bookworm uses 16px
+    -->
+    <g transform="translate(30 10)">
+        <line x1="0" y1="0" x2="4.166em" y2="0"  class="font-dependent" id="em-H"/>
+        <line x1="0" y1="0" x2="0" y2="4.166em" class="font-dependent"  id="em-V"/>
+    </g>
+
+    <!-- 1ex = font dependent.
+        Inkscape 1.3.2 on debian bookworm uses 6px (used for this test)
+        Firefox 115.5 on debian bookworm uses 8px
+    -->
+    <g transform="translate(35 15)">
+        <line x1="0" y1="0" x2="8.333333333ex" y2="0" class="font-dependent" id="ex-H"/>
+        <line x1="0" y1="0" x2="0" y2="8.333333ex" class="font-dependent"  id="ex-V"/>
+    </g>
+
+    <!-- 1% = document dimension / 100. 
+        This is the only unit that is directional, e.g. height is different from width.
+    -->
+    <g transform="translate(40 20)">
+        <line x1="0" y1="0" x2="50%" y2="0"  id="pct-H"/>
+        <line x1="0" y1="0" x2="0" y2="25%"  id="pct-V"/>
+    </g>
+
+    <!-- 1pt = 96dpi / 72pt/in -->
+    <g transform="translate(45 25)">
+        <line x1="0" y1="0" x2="37.5pt" y2="0"  id="pt-H"/>
+        <line x1="0" y1="0" x2="0" y2="37.5pt"  id="pt-V"/>
+    </g>
+
+    <!-- 1pc = 96dpi / 6pc/in -->-->
+    <g transform="translate(50 30)">
+        <line x1="0" y1="0" x2="3.125pc" y2="0"  id="pc-H"/>
+        <line x1="0" y1="0" x2="0" y2="3.125pc"  id="pc-V"/>
+    </g>
+</svg>

--- a/lib/tests/dimensions.svg
+++ b/lib/tests/dimensions.svg
@@ -2,7 +2,7 @@
 <svg
     width="200mm"
     height="400mm"
-    viewBox="0 -20 100 200"
+    viewBox="0 0 100 200"
     xmlns="http://www.w3.org/2000/svg"
     version="1.1"
 >
@@ -31,39 +31,43 @@
         .font-dependent {
             stroke: #f00;
         }
+    
+        #page-bounds {
+            stroke: #000;
+            stroke-width: 0.5;
+        }
     </style>
 
-    <!-- A line around the page, so a visual inspection is easy -->
-    <g transform="translate(0 -20)">
-        <polygon  points="0,0 0,100 100,100 100,0 0,0" id="page-bounds"/>
-    </g>
+    <!-- A line around the page, so visual inspection is easy -->
+    <polygon  points="0,0 0,100 100,100 100,0" id="page-bounds" />
+    <!-- polygon  points="0,0 0,100 100,100 100,0" id="page-bounds"/ -->
 
-    <!-- Unitless (equivalent to pixels)-->
-    <g transform="translate(5 -15)">
+    Unitless (equivalent to pixels)
+    <g transform="translate(5 5)">
         <line x1="0" y1="0" x2="50" y2="0" id="unitless-H" />
         <line x1="0" y1="0" x2="0" y2="50" id="unitless-V" />
     </g>
 
     <!-- px -->
-    <g transform="translate(10 -10)">
+    <g transform="translate(10 10)">
         <line x1="0" y1="0" x2="50px" y2="0"  id="px-H"/>
         <line x1="0" y1="0" x2="0" y2="50px"  id="px-V"/>
     </g>
 
     <!-- 1mm = (96dpi / 25.4mm/in ) px -->
-    <g transform="translate(15 -5)">
+    <g transform="translate(15 15)">
         <line x1="0" y1="0" x2="13.3333333mm" y2="0"  id="mm-H"/>
         <line x1="0" y1="0" x2="0" y2="13.333333mm"  id="mm-V"/>
     </g>
 
     <!-- 1cm = (96dpi / 2.54cm/in ) px -->
-    <g transform="translate(20 0)">
+    <g transform="translate(20 20)">
         <line x1="0" y1="0" x2="1.33333333cm" y2="0"  id="cm-H"/>
         <line x1="0" y1="0" x2="0" y2="1.3333333cm"  id="cm-V"/>
     </g>
 
     <!-- 1in = (96dpi) px -->
-    <g transform="translate(25 5)">
+    <g transform="translate(25 25)">
         <line x1="0" y1="0" x2=".52083in" y2="0"  id="in-H"/>
         <line x1="0" y1="0" x2="0" y2=".52083in"  id="in-V"/>
     </g>
@@ -72,7 +76,7 @@
         Inkscape 1.3.2 on debian bookworm uses 12px (used for this test)
         Firefox 115.5 on debian bookworm uses 16px
     -->
-    <g transform="translate(30 10)">
+    <g transform="translate(30 30)">
         <line x1="0" y1="0" x2="4.166em" y2="0"  class="font-dependent" id="em-H"/>
         <line x1="0" y1="0" x2="0" y2="4.166em" class="font-dependent"  id="em-V"/>
     </g>
@@ -81,7 +85,7 @@
         Inkscape 1.3.2 on debian bookworm uses 6px (used for this test)
         Firefox 115.5 on debian bookworm uses 8px
     -->
-    <g transform="translate(35 15)">
+    <g transform="translate(35 35)">
         <line x1="0" y1="0" x2="8.333333333ex" y2="0" class="font-dependent" id="ex-H"/>
         <line x1="0" y1="0" x2="0" y2="8.333333ex" class="font-dependent"  id="ex-V"/>
     </g>
@@ -89,19 +93,19 @@
     <!-- 1% = document dimension / 100. 
         This is the only unit that is directional, e.g. height is different from width.
     -->
-    <g transform="translate(40 20)">
+    <g transform="translate(40 40)">
         <line x1="0" y1="0" x2="50%" y2="0"  id="pct-H"/>
         <line x1="0" y1="0" x2="0" y2="25%"  id="pct-V"/>
     </g>
 
     <!-- 1pt = 96dpi / 72pt/in -->
-    <g transform="translate(45 25)">
+    <g transform="translate(45 45)">
         <line x1="0" y1="0" x2="37.5pt" y2="0"  id="pt-H"/>
         <line x1="0" y1="0" x2="0" y2="37.5pt"  id="pt-V"/>
     </g>
 
-    <!-- 1pc = 96dpi / 6pc/in -->-->
-    <g transform="translate(50 30)">
+    <!-- 1pc = 96dpi / 6pc/in -->
+    <g transform="translate(50 50)">
         <line x1="0" y1="0" x2="3.125pc" y2="0"  id="pc-H"/>
         <line x1="0" y1="0" x2="0" y2="3.125pc"  id="pc-V"/>
     </g>


### PR DESCRIPTION
I added support for `rect`, `circle`, `ellipse`, `polyline` and `line`. I believe that completes support for shapes (not counting text here). I also fixed a bug when converting the px unit to mm.

Unfortunately, this implementation is not yet correct, as the coordinate system needs a bit of rework first. Right now, the viewport is treated as a fixed transform, in combination with the width and height of the document. That is not correct - those transforms should only apply to dimensions without units. Dimensions with units should remain untransformed. I will address that in a separate MR.