### PR TITLE
Use default values for properties missing from --settings file

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -122,9 +122,7 @@ fn main() -> io::Result<()> {
 
     let settings = {
         let mut settings = if let Some(path) = opt.settings {
-            let defaults = serde_json::to_value(Settings::default()).unwrap();
-            let overrides = serde_json::from_reader(File::open(path)?)?;
-            serde_json::from_value(merge(defaults, overrides))?
+            serde_json::from_reader(File::open(path)?)?
         } else {
             Settings::default()
         };
@@ -384,18 +382,5 @@ fn main() -> io::Result<()> {
             },
             std::io::stdout(),
         )
-    }
-}
-
-fn merge(defaults: serde_json::Value, overrides: serde_json::Value) -> serde_json::Value {
-    match (defaults, overrides) {
-        (serde_json::Value::Object(mut defaults), serde_json::Value::Object(overrides)) => {
-            for (k, v) in overrides {
-                let existing = defaults.remove(&k).unwrap_or(serde_json::Value::Null);
-                defaults.insert(k, merge(existing, v));
-            }
-            serde_json::Value::Object(defaults)
-        }
-        (_, overrides) => overrides,
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -122,7 +122,9 @@ fn main() -> io::Result<()> {
 
     let settings = {
         let mut settings = if let Some(path) = opt.settings {
-            serde_json::from_reader(File::open(path)?)?
+            let defaults = serde_json::to_value(Settings::default()).unwrap();
+            let overrides = serde_json::from_reader(File::open(path)?)?;
+            serde_json::from_value(merge(defaults, overrides))?
         } else {
             Settings::default()
         };
@@ -382,5 +384,18 @@ fn main() -> io::Result<()> {
             },
             std::io::stdout(),
         )
+    }
+}
+
+fn merge(defaults: serde_json::Value, overrides: serde_json::Value) -> serde_json::Value {
+    match (defaults, overrides) {
+        (serde_json::Value::Object(mut defaults), serde_json::Value::Object(overrides)) => {
+            for (k, v) in overrides {
+                let existing = defaults.remove(&k).unwrap_or(serde_json::Value::Null);
+                defaults.insert(k, merge(existing, v));
+            }
+            serde_json::Value::Object(defaults)
+        }
+        (_, overrides) => overrides,
     }
 }

--- a/g_code/src/config/mod.rs
+++ b/g_code/src/config/mod.rs
@@ -23,6 +23,7 @@ mod v5;
 
 /// A cross-platform type used to store all configuration types.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Settings {
     pub conversion: GCodeConfig,
@@ -33,6 +34,7 @@ pub struct Settings {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct MachineConfig {
     pub supported_functionality: SupportedFunctionality,
@@ -43,6 +45,7 @@ pub struct MachineConfig {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct GCodeConfig {
     #[cfg_attr(feature = "serde", serde(flatten))]
@@ -63,6 +66,7 @@ impl Default for GCodeConfig {
 
 #[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct SupportedFunctionality {
     /// Indicates support for G2/G3 circular interpolation.
     ///
@@ -71,17 +75,15 @@ pub struct SupportedFunctionality {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 #[derive(Debug, Default, Clone, PartialEq)]
 /// Operations performed after G-Code generation.
 pub struct PostprocessConfig {
     /// Convenience field for [g_code::emit::FormatOptions] field
-    #[cfg_attr(feature = "serde", serde(default))]
     pub checksums: bool,
     /// Convenience field for [g_code::emit::FormatOptions] field
-    #[cfg_attr(feature = "serde", serde(default))]
     pub line_numbers: bool,
     /// Convenience field for [g_code::emit::FormatOptions] field
-    #[cfg_attr(feature = "serde", serde(default))]
     pub newline_before_comment: bool,
 }
 

--- a/star/src/lower/mod.rs
+++ b/star/src/lower/mod.rs
@@ -30,23 +30,21 @@ mod visit;
 /// High-level output configuration
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct ConversionConfig {
     /// Dots per inch for pixels, picas, points, etc.
     pub dpi: f64,
     /// Set the origin point in millimeters for this conversion
-    #[cfg_attr(feature = "serde", serde(default = "zero_origin"))]
     pub origin: [Option<f64>; 2],
     /// Set extra attribute to add when printing node name
     pub extra_attribute_name: Option<String>,
     /// Reorder paths to minimize travel time
-    #[cfg_attr(feature = "serde", serde(default))]
     pub optimize_path_order: bool,
     /// CSS selector to filter which SVG elements are converted.
     ///
     /// Only the `:not`, `:is`, and `:has` pseudo classes are supported.
     ///
     /// <https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Selectors>
-    #[cfg_attr(feature = "serde", serde(default))]
     pub selector_filter: Option<String>,
     pub starting_point: [Option<f64>; 2],
 }


### PR DESCRIPTION
Use default values for properties missing from --settings file.

This allows for a minimal settings file, such as
```
{
  "conversion": {
    "feedrate": 4500
  },
  "postprocess": {
    "newline_before_comment": true
  }
}
```