### PR TITLE
Fix newline_before_comment in file output.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -367,6 +367,7 @@ fn main() -> io::Result<()> {
             FormatOptions {
                 line_numbers: settings.postprocess.line_numbers,
                 checksums: settings.postprocess.checksums,
+                newline_before_comment: settings.postprocess.newline_before_comment,
                 ..Default::default()
             },
             File::create(out_path)?,


### PR DESCRIPTION
Fix `newline_before_comment` in file output. 
The value not honored when outputting to a file, and it was incorrectly always `false`.